### PR TITLE
リファクタリング: 未貸出商品/会員一覧取得の処理

### DIFF
--- a/src/main/java/com/urassh/dvdrental/usecase/goods/GetUnRentedGoodsUseCase.java
+++ b/src/main/java/com/urassh/dvdrental/usecase/goods/GetUnRentedGoodsUseCase.java
@@ -26,17 +26,9 @@ public class GetUnRentedGoodsUseCase {
 
             // 商品情報リポジトリから商品情報をすべて取得してリストに格納
             // その後、貸出情報リポジトリに商品IDが登録されている商品をリストからのぞく
-            List<Rental> rentalList = rentalRepository.getAll().join();
-            List<Goods> goodsList = goodsRepository.getAll().join();
-            List<Goods> unRentedGoodsList = new ArrayList<>();
+            List<Goods> unRentedGoodsList = goodsRepository.getAll().join();
 
-            for (Goods goods : goodsList) {
-                for (Rental rental : rentalList) {
-                    if (!goods.getId().equals(rental.getGoodsId())) {
-                        unRentedGoodsList.add(goods);
-                    }
-                }
-            }
+            unRentedGoodsList.removeIf(goods -> rentalRepository.getByGoodsId(goods.getId()).join() != null);
 
             return unRentedGoodsList;
         });

--- a/src/main/java/com/urassh/dvdrental/usecase/rental/GetUnRentingMemberUseCase.java
+++ b/src/main/java/com/urassh/dvdrental/usecase/rental/GetUnRentingMemberUseCase.java
@@ -1,13 +1,11 @@
 package com.urassh.dvdrental.usecase.rental;
 
 import com.urassh.dvdrental.domain.Member;
-import com.urassh.dvdrental.domain.Rental;
 import com.urassh.dvdrental.domain.interfaces.MemberRepository;
 import com.urassh.dvdrental.domain.interfaces.RentalRepository;
 import com.urassh.dvdrental.infrastructure.MemberDummyRepository;
 import com.urassh.dvdrental.infrastructure.RentalDummyRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -23,19 +21,11 @@ public class GetUnRentingMemberUseCase {
                 throw new RuntimeException(e);
             }
 
-            // 商品情報リポジトリから商品情報をすべて取得してリストに格納
-            // その後、貸出情報リポジトリに商品IDが登録されている商品をリストからのぞく
-            List<Rental> rentalList = rentalRepository.getAll().join();
-            List<Member> memberList = memberRepository.getAll().join();
-            List<Member> unRentingMemberList = new ArrayList<>();
+            // 会員情報リポジトリから会員情報をすべて取得してリストに格納
+            // その後、貸出情報リポジトリに会員IDが登録されている会員をリストからのぞく
+            List<Member> unRentingMemberList = memberRepository.getAll().join();
 
-            for (Member member : memberList) {
-                for (Rental rental : rentalList) {
-                    if (!member.getId().equals(rental.getGoodsId())) {
-                        unRentingMemberList.add(member);
-                    }
-                }
-            }
+            unRentingMemberList.removeIf(member -> rentalRepository.getByMemberId(member.getId()).join() != null);
 
             return unRentingMemberList;
         });


### PR DESCRIPTION
こちらのユースケースも処理を単純化してみた。
しかし removeIf 内で join(非同期処理を送って待つやつ) が頻繁に発生することになるので、かえって無駄が多い気がする。あってる?

その場合、for文だけをremoveIfで省略すればいいのかな？