### PR TITLE
貸出カート画面の入力エラーハイライト

### DIFF
--- a/src/main/java/com/urassh/dvdrental/controller/rental/RentalCartController.java
+++ b/src/main/java/com/urassh/dvdrental/controller/rental/RentalCartController.java
@@ -14,6 +14,7 @@ import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.fxml.FXML;
+import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
@@ -92,6 +93,7 @@ public class RentalCartController {
     }
 
     public void onConfirmRental() {
+        ErrorControlHighlight(searchField, rentingMember == null);
         if (rentingMember == null) return;
         if (rentalCart.isEmpty()) return;
 
@@ -129,5 +131,16 @@ public class RentalCartController {
     private void onCancelRental(Goods goods) {
         new RemoveFromCartUseCase().execute(goods);
         loadCarts();
+    }
+
+    private void ErrorControlHighlight(Control control, boolean hasError) {
+        String errorClass = "error";
+        if (hasError) {
+            if (!control.getStyleClass().contains(errorClass)) {
+                control.getStyleClass().add(errorClass);
+            }
+        } else {
+            control.getStyleClass().remove(errorClass);
+        }
     }
 }

--- a/src/main/resources/com/urassh/dvdrental/rental/cart/style.css
+++ b/src/main/resources/com/urassh/dvdrental/rental/cart/style.css
@@ -69,6 +69,10 @@
     -fx-background-radius: 10;
 }
 
+.search-field.error {
+    -fx-border-color: red;
+}
+
 .search-field:focused {
     -fx-border-color: #4a90e2;
 }


### PR DESCRIPTION
貸出会員の入力エラーハイライト。
会員が指定されていないときに確定ボタンを押したとき。
`ErrorControlHighlight`

![image](https://github.com/user-attachments/assets/7430872c-e659-4e7a-8368-e5953f2e3816)
