### PR TITLE
延滞料金合計のラベルをリネーム

### DIFF
--- a/src/main/java/com/urassh/dvdrental/controller/returns/detail/ReturnDetailController.java
+++ b/src/main/java/com/urassh/dvdrental/controller/returns/detail/ReturnDetailController.java
@@ -47,7 +47,7 @@ public class ReturnDetailController {
     public void setRental(Rental rental) {
         memberIdLabel.setText(rental.getMember().getId().toString());
         memberNameLabel.setText(rental.getMember().getName());
-        lateFeeLabel.setText("遅延料金 : 0円 (税込)");
+        lateFeeLabel.setText("延滞料金合計 : 0円 (税込)");
 
         getRentalsByMemberUseCase.execute(rental.getMember())
             .thenAccept(rentals -> {
@@ -83,7 +83,7 @@ public class ReturnDetailController {
                         .map(Rental::getLateFee)
                         .reduce(Money.ZERO, Money::add);
 
-                lateFeeLabel.setText("遅延料金 : " + sumLateFee.withTax().getValue() + "円 (税込)");
+                lateFeeLabel.setText("延滞料金合計 : " + sumLateFee.withTax().getValue() + "円 (税込)");
             }
         };
     }


### PR DESCRIPTION
![スクリーンショット (1402)](https://github.com/user-attachments/assets/91974c69-6741-4759-8a17-3c1f6cccaaae)
![スクリーンショット (1401)](https://github.com/user-attachments/assets/0c1a57cf-8677-44ec-b536-a9d4663129c8)
二か所書き変えただけ
featureじゃなくてfixだったかも